### PR TITLE
Add link to IETF's GeoJSON standards document

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ Some tips for creating open data in a way that is helpful. The aim is to make yo
 
 
 ## GIS data
-* Shapefiles are good but it can make life easier for those without desktop GIS software if you **also provide data as GeoJSON** (plain text). Your GIS software should be able to export as GeoJSON;
+* Shapefiles are good but it can make life easier for those without desktop GIS software if you **also provide data as GeoJSON** (plain text). Your GIS software should be able to export as GeoJSON and you can look at IETF's [RFC 7946](https://tools.ietf.org/html/rfc7946) standard if you want to know how the format works in detail;
 * Provide **longitudes and latitudes**, not just eastings and northings;
 * Think about the number of **decimal places** you provide for longitudes and latitudes. The more decimal places you provide the bigger the file size. You only need to provide as many decimal places as the precision of your measurements. One degree of latitude/longitude on Earth is, at most, about 111km. Therefore, five decimal places gives an accuracy of about 1 metre. It is highly unlikely that you’ve measured the location of a bus stop to the scale of an atomic nucleus so don’t provide the coordinates to 16 decimal places. I shaved ~700kB off one 2MB GeoJSON file just by truncating the precision to 5 decimal places.


### PR DESCRIPTION
Useful to link to the current authoritative source (as of August 2016) on GeoJSON.